### PR TITLE
Added Grant Distribution and Voting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -827,9 +827,9 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "steem-state": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/steem-state/-/steem-state-1.2.0.tgz",
-      "integrity": "sha512-kfjRB0c9rob1C5yYKAkw28w5gYwHnrQqvxm9V1jqf4hKncbl+HNH5SMD49lwQofxiYAPtVga+hl2opKr5m4QNw=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/steem-state/-/steem-state-1.3.2.tgz",
+      "integrity": "sha512-pmrJdM7gDf8SelUlrIJBBNiN5ms/MOEblb3hV+Dgg0PdjunT1IuB9aI9XuWYXCppc33+/i/JPrjUyhhnw6jI6g=="
     },
     "steem-transact": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express": "^4.16.4",
     "match-schema": "^0.1.0",
     "mocha": "^5.2.0",
-    "steem-state": "^1.2.0",
+    "steem-state": "^1.3.2",
     "steem-transact": "^1.0.2"
   }
 }

--- a/src/apps/grant-voting/index.js
+++ b/src/apps/grant-voting/index.js
@@ -72,6 +72,14 @@ function cli(input, getState) {
 }
 
 function api(app, getState) {
+  app.get('/grant-voting/granters', (req, res, next) => {
+    res.send(JSON.stringify(getState().granters, null, 2));
+  });
+
+  app.get('/grant-voting/@:username', (req, res, next) => {
+    res.send(JSON.stringify(getState().granterVotes[req.params.username], null, 2));
+  });
+
   return app
 }
 

--- a/src/apps/grant-voting/index.js
+++ b/src/apps/grant-voting/index.js
@@ -1,0 +1,82 @@
+const matcher = require('match-schema');
+const schemas = require('./schemas');
+
+const maxGrantersVote = 11;
+
+function app(processor, getState, setState, prefix) {
+  if(!getState().granters) {
+    var state = getState();
+    state.granters = {};
+    setState(state);
+  }
+
+  processor.on('become_granter', function(json, from) {
+    var state = getState();
+
+    state.granters[from] = true;
+
+    console.log(from, 'became a granter')
+    setState(state);
+  });
+
+  processor.on('stop_granter', function(json, from) {
+    var state = getState();
+
+    state.granters[from] = undefined;
+    console.log(from, 'exited granter role')
+    setState(state);
+  });
+
+  processor.on('granter_vote', function(json, from) {
+    var state = getState();
+
+    if(json instanceof Array && json.length <= maxGrantersVote) {
+      console.log(from, 'changed granter votes to', json);
+      if(!state.granterVotes) { state.granterVotes = {};}
+      state.granterVotes[from] = json;
+    } else {
+      console.log('Invalid granter vote from', from);
+    }
+
+    setState(state);
+  });
+
+
+  return processor
+}
+
+function cli(input, getState) {
+  input.on('become_granter', function(args, transactor, username, key) {
+    transactor.json(username, key, 'become_granter', {}, function(err, result) {
+      if(err) {
+        console.error(err);
+      }
+    });
+  });
+
+  input.on('stop_granter', function(args, transactor, username, key) {
+    transactor.json(username, key, 'stop_granter', {}, function(err, result) {
+      if(err) {
+        console.error(err);
+      }
+    });
+  });
+
+  input.on('granter_vote', function(args, transactor, username, key) {
+    transactor.json(username, key, 'granter_vote', args, function(err, result) {
+      if(err) {
+        console.error(err);
+      }
+    });
+  });
+}
+
+function api(app, getState) {
+  return app
+}
+
+module.exports = {
+  app: app,
+  cli: cli,
+  api: api
+}

--- a/src/apps/grant-voting/index.js
+++ b/src/apps/grant-voting/index.js
@@ -1,7 +1,7 @@
 const matcher = require('match-schema');
 const schemas = require('./schemas');
 
-const maxGrantersVote = 11;
+const maxGrantersVote = 3;
 
 function app(processor, getState, setState, prefix) {
   if(!getState().granters) {

--- a/src/distribute_grants.js
+++ b/src/distribute_grants.js
@@ -1,0 +1,74 @@
+
+const maxGranters = 11;
+
+function distributeGrants(state, block) {
+  if(!state.rewardPool) {
+    console.error("Error: state.rewardPool is undefined.");
+  }
+
+  console.log('Distributing daily grants, reward pool is', state.rewardPool);
+
+  // Next we will add up all stake of all voters for each granter, and the top
+  // [maxGranters] granters will split the reward pool.
+
+  const granterVoteCount = {};
+
+  for (var granter in state.granters) { // Set all granters' vote count to 0
+    granterVoteCount[granter] = 0;
+  }
+
+  for (var voter in state.granterVotes) {
+    for (var i in state.granterVotes[voter]) {
+      const granter = state.granterVotes[voter][i];
+      if(state.granters[granter] !== undefined) { // If the user voted for is actually a granter
+        granterVoteCount[granter] += state.balances[voter] || 0;
+      }
+    }
+  }
+
+  const granterArray = [];  // We need to turn the granterVoteCount object into an array to sort.
+
+  for (var granter in granterVoteCount) {
+    granterArray.push({granter: granter, votes: granterVoteCount[granter]});
+  }
+
+  const sortedGranters = granterArray.sort(function (a, b) {
+    const difference = b.votes - a.votes;
+
+    if(difference === 0) {        // If no difference, rely on alphabetical order.
+      return a.granter > b.granter;
+    }
+
+    return difference;
+  });
+
+  const topGranters = sortedGranters.slice(0, maxGranters);
+
+  // Distribute rewards
+  const rewardPerGranter = Math.floor(state.rewardPool/topGranters.length);
+
+  for(granterNum in topGranters) {
+    const granter = topGranters[granterNum].granter;
+    console.log("Top granter",granter,"received",rewardPerGranter);
+
+    if(state.balances[granter] === undefined) {
+      state.balances[granter] = 0;
+    }
+
+    state.balances[granter] += rewardPerGranter;
+  }
+
+
+
+  state.rewardPool = getRewardPool(block);
+  return state;
+}
+
+// Placeholder reward pool function. Actual function TBD.
+function getRewardPool(block) {
+  return dailyRewardDistribution = 100000;
+}
+
+
+
+module.exports = distributeGrants;

--- a/src/distribute_grants.js
+++ b/src/distribute_grants.js
@@ -1,5 +1,5 @@
 
-const maxGranters = 11;
+const maxGranters = 3;
 
 function distributeGrants(state, block) {
   if(!state.rewardPool) {

--- a/src/genesis.js
+++ b/src/genesis.js
@@ -2,12 +2,12 @@ const genesisState = {
   balances: {
     shredz7: 9900000,
     ausbitbank: 100000,
-    "state-tester": 1000000,
-    ra: 10000000
+    "state-tester": 1000000
   },
-  dex: {
-
-  }
+  dex: {},
+  granters: {},
+  rewardPool: 100000,
+  granterVotes: {}
 };
 
 const genesisBlock = 28934806;

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,9 @@ const bodyParser = require('body-parser');
 const genesis = require('./genesis');
 const dex = require('./apps/dex');
 const token = require('./apps/token');
+const grantVoting = require('./apps/grant-voting');
+
+const distributeGrants = require('./distribute_grants');
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -30,7 +33,6 @@ function setState(value) {
 }
 
 const prefix = 'engine_'
-const dappCreationFee = 1000;
 
 const streamMode = process.env.STREAM_MODE || 'irreversible'  // Stream irreversible or latest?
 console.log('Using mode', streamMode)
@@ -65,10 +67,10 @@ function startApp(startingBlock) {
     if(num % 100 === 0) {
       saveState(num, state)
     }
-
-    //if(num % 28800 === 0) { // Every day
-      distributeGrants();
-    //}
+    //if(num % 100 === 0) { // For grant distribution testing
+    if(num % 28800 === 0) { // Every day
+      state = distributeGrants(state, num);
+    }
   });
 
   processor.onStreamingStart(function() {
@@ -77,6 +79,7 @@ function startApp(startingBlock) {
 
   processor = token.app(processor,getState,setState, fullPrefix);
   processor = dex.app(processor,getState,setState, fullPrefix);
+  processor = grantVoting.app(processor, getState, setState, fullPrefix);
 
   processor.start();
   console.log('Started state processor.');
@@ -97,6 +100,7 @@ function startApp(startingBlock) {
 
   token.cli(inputInterface, getState);
   dex.cli(inputInterface, getState);
+  grantVoting.cli(inputInterface, getState);
 
 
   rl.on('line', function(data) {
@@ -122,6 +126,7 @@ function startApp(startingBlock) {
 
   app = token.api(app, getState);
   app = dex.api(app, getState);
+  app = grantVoting.api(app, getState);
 
   app.listen(port, function() {
     console.log(`Engine API listening on port ${port}!`)
@@ -161,9 +166,4 @@ if(fs.existsSync(stateStoreFile)) { // If we have saved the state in a previous 
   console.log('No state store file found. Starting from the genesis block + state (this is not a warning, everything is OK, this is to be expected)');
   const startingBlock = genesisBlock;  // Simply start at the genesis block.
   startApp(startingBlock);
-}
-
-
-function distributeGrants() {
-  console.log('distributing grants');
 }

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,10 @@ function startApp(startingBlock) {
     if(num % 100 === 0) {
       saveState(num, state)
     }
+
+    //if(num % 28800 === 0) { // Every day
+      distributeGrants();
+    //}
   });
 
   processor.onStreamingStart(function() {
@@ -113,7 +117,7 @@ function startApp(startingBlock) {
   });
 
   app.get('/state', (req, res, next) => {
-    res.send(JSON.stringify(state, null, 2))
+    res.send(JSON.stringify([processor.getCurrentBlockNumber(),state], null, 2))
   });
 
   app = token.api(app, getState);
@@ -157,4 +161,9 @@ if(fs.existsSync(stateStoreFile)) { // If we have saved the state in a previous 
   console.log('No state store file found. Starting from the genesis block + state (this is not a warning, everything is OK, this is to be expected)');
   const startingBlock = genesisBlock;  // Simply start at the genesis block.
   startApp(startingBlock);
+}
+
+
+function distributeGrants() {
+  console.log('distributing grants');
 }

--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ function startApp(startingBlock) {
   app.use(bodyParser.json());
 
   app.get('/', (req, res, next) => {
-    res.send(JSON.stringify({block: processor.getCurrentBlockNumber()}, null, 2))
+    res.send(JSON.stringify({block: processor.getCurrentBlockNumber(), latest: processor.isStreaming()}, null, 2))
   });
 
   app.get('/state', (req, res, next) => {

--- a/test/distribute-grants-test.js
+++ b/test/distribute-grants-test.js
@@ -1,0 +1,39 @@
+const expect = require('chai').expect
+
+const distributeGrants = require('./../src/distribute_grants')
+
+describe('grant distribution', function() {
+  it('Successfully distributes grants to two users',function() {
+    state = {
+      balances: {
+        alice: 100000,
+        bob: 2200,
+        carl: 1000
+      },
+      dex: {},
+      granters: {
+        alice: true,
+        bob: true
+      },
+      rewardPool: 2000,
+      granterVotes: {
+        alice: [
+          'bob',
+          'alice'
+        ],
+        bob: [
+          'bob'
+        ],
+        carl: [
+          'alice'
+        ]
+      }
+    };
+
+    state = distributeGrants(state, 20);
+
+    expect(state.balances.alice).to.eql(101000);
+    expect(state.balances.bob).to.eql(3200);
+    expect(state.balances.carl).to.eql(1000);
+  });
+});


### PR DESCRIPTION
Anyone will be able to become a 'granter', meaning they will be able to receive daily SRTS inflation, by using the operation `become_granter`. They can also stop being a granter by using operation `stop_granter`. 

A user can vote for 11 granters at max, which they vote for using `granter_vote` with an array of the usernames they wish to vote for. Then, 11 top granters are selected each day by summing up all votes (stake-weighted), which each receive one share of the daily reward pool. The daily reward pool can be added to by any subapp as profits from certain activities (such as paying for name selection, etc.) and will also be added to automatically from inflation from a preditermined curve (not created yet, see `getRewardPool(block)` in distribute_grants.js).

API endpoints: `/grant-voting/granters` to get all granters and `/grant-voting/@[username]` to get granter votes of user [username].

Any ideas for improvements, errors, etc? If there are no comments this PR will be automatically confirmed on Sunday.