### PR TITLE
Communities Implementation MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 states/
 state.json
+db/
 
 # Above this line was added for the Engine project, below is from gitignore.io
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -13,10 +18,48 @@
         "negotiator": "0.6.1"
       }
     },
+    "ajv": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+      "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+      "requires": {
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
+      }
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -27,6 +70,21 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -39,6 +97,14 @@
       "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
       "requires": {
         "safe-buffer": "5.1.2"
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "0.14.5"
       }
     },
     "bindings": {
@@ -144,6 +210,11 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
@@ -162,6 +233,11 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
+    "chownr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -169,6 +245,19 @@
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.2"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "requires": {
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -180,6 +269,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -236,6 +330,14 @@
         "sha.js": "2.4.11"
       }
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -252,6 +354,21 @@
         "type-detect": "4.0.8"
       }
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -261,6 +378,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diff": {
       "version": "3.5.0",
@@ -289,6 +411,15 @@
         "secp256k1": "3.6.0",
         "verror": "1.10.0",
         "whatwg-fetch": "3.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "ee-first": {
@@ -391,10 +522,25 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "extsprintf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
       "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8="
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "finalhandler": {
       "version": "1.1.1",
@@ -425,6 +571,21 @@
         }
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.21"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -435,15 +596,46 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "requires": {
+        "minipass": "2.3.5"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
+      }
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.2",
@@ -463,10 +655,29 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "requires": {
+        "ajv": "6.7.0",
+        "har-schema": "2.0.0"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hash-base": {
       "version": "3.0.4",
@@ -512,12 +723,30 @@
         "statuses": "1.5.0"
       }
     },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
         "safer-buffer": "2.1.2"
+      }
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "requires": {
+        "minimatch": "3.0.4"
       }
     },
     "inflight": {
@@ -534,10 +763,76 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "extsprintf": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        }
+      }
     },
     "long": {
       "version": "3.2.0",
@@ -615,6 +910,23 @@
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "requires": {
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "requires": {
+        "minipass": "2.3.5"
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -651,6 +963,26 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
       "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
+    "needle": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
+      "requires": {
+        "debug": "2.6.9",
+        "iconv-lite": "0.4.23",
+        "sax": "1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -660,6 +992,72 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+    },
+    "node-pre-gyp": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
+      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+      "requires": {
+        "detect-libc": "1.0.3",
+        "mkdirp": "0.5.1",
+        "needle": "2.2.4",
+        "nopt": "4.0.1",
+        "npm-packlist": "1.2.0",
+        "npmlog": "4.1.2",
+        "rc": "1.2.8",
+        "rimraf": "2.6.3",
+        "semver": "5.6.0",
+        "tar": "4.4.8"
+      }
+    },
+    "nopt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "requires": {
+        "abbrev": "1.1.1",
+        "osenv": "0.1.5"
+      }
+    },
+    "npm-bundled": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+      "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g=="
+    },
+    "npm-packlist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
+      "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
+      "requires": {
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.5"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-hash": {
       "version": "1.3.1",
@@ -682,6 +1080,25 @@
         "wrappy": "1.0.2"
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
@@ -702,6 +1119,16 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
     "proxy-addr": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
@@ -710,6 +1137,16 @@
         "forwarded": "0.1.2",
         "ipaddr.js": "1.8.0"
       }
+    },
+    "psl": {
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -732,6 +1169,88 @@
         "unpipe": "1.0.0"
       }
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.21",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "requires": {
+        "glob": "7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
@@ -751,6 +1270,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "secp256k1": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.6.0.tgz",
@@ -765,6 +1289,11 @@
         "nan": "2.12.1",
         "safe-buffer": "5.1.2"
       }
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "send": {
       "version": "0.16.2",
@@ -812,6 +1341,11 @@
         "send": "0.16.2"
       }
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
@@ -824,6 +1358,44 @@
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.2"
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "sqlite3": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.6.tgz",
+      "integrity": "sha512-EqBXxHdKiwvNMRCgml86VTL5TK1i0IKiumnfxykX0gh6H6jaKijAXvE9O1N7+omfNSawR2fOmIyJZcfe8HYWpw==",
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.11.0",
+        "request": "2.88.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+        }
+      }
+    },
+    "sshpk": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+      "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
+      "requires": {
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "statuses": {
@@ -841,6 +1413,37 @@
       "resolved": "https://registry.npmjs.org/steem-transact/-/steem-transact-1.0.2.tgz",
       "integrity": "sha512-zb76a5QfFS5PQYkxDncHZfJ8syhj5IwGu2UHaet6BrACXBAY+jVqH4YK0AwDiySqOxjmNiwmG77kiLCidL8YgQ=="
     },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
     "supports-color": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -848,6 +1451,49 @@
       "requires": {
         "has-flag": "3.0.0"
       }
+    },
+    "tar": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "requires": {
+        "chownr": "1.1.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.3.5",
+        "minizlib": "1.2.1",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "requires": {
+        "psl": "1.1.31",
+        "punycode": "1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-detect": {
       "version": "4.0.8",
@@ -868,10 +1514,28 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "2.1.1"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "vary": {
       "version": "1.1.2",
@@ -893,10 +1557,23 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
       "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yallist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -545,9 +545,9 @@
       "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
     },
     "match-schema": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/match-schema/-/match-schema-0.1.0.tgz",
-      "integrity": "sha512-PeHFfK1MwDEXFpbpZ5Xd0qrX3LToomz27aAL2sNw+zuJCI2vXMvqlaQUbcmnrPvfjoHBiGOfi3CNu1fwCxubzA=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/match-schema/-/match-schema-0.2.0.tgz",
+      "integrity": "sha512-Gq8uzRLp1bSm0dh99ExhoQ/bdb/UhcJ7ImPbZHc4FUhn9L8IOBWgBGBkMOjlVkT746XK6JHXeN58BpSim8IuhA=="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "match-schema": "^0.2.0",
     "mocha": "^5.2.0",
     "object-hash": "^1.3.1",
+    "sqlite3": "^4.0.6",
     "steem-state": "^1.3.2",
     "steem-transact": "^1.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chai": "^4.2.0",
     "dsteem": "^0.11.2",
     "express": "^4.16.4",
-    "match-schema": "^0.1.0",
+    "match-schema": "^0.2.0",
     "mocha": "^5.2.0",
     "object-hash": "^1.3.1",
     "steem-state": "^1.3.2",

--- a/src/apps/communities/database.js
+++ b/src/apps/communities/database.js
@@ -1,0 +1,22 @@
+const sqlite3 = require('sqlite3').verbose();
+const fs = require('fs');
+
+const dbLocation = 'db/communities.db';
+
+if(!fs.existsSync(dbLocation)) {
+  fs.mkdirSync('db/')
+  const createStream = fs.createWriteStream('db/communities.db');
+  createStream.end();
+}
+
+const db = new sqlite3.Database(dbLocation);
+
+return {
+  post: function() {
+
+  },
+
+  create: function() {
+
+  }
+}

--- a/src/apps/communities/database.js
+++ b/src/apps/communities/database.js
@@ -1,3 +1,14 @@
+/*
+  Communities DB
+  ---
+
+  This stores communities data in a database. This data is all data that is not
+  required for future consensus. For example, there is no need to know a community's
+  posts to be able to determine what posts will be accepted in the future. But end
+  users will most definitely want to know a community's posts. So we store this data
+  in a local database, SQLite3.
+*/
+
 const sqlite3 = require('sqlite3').verbose();
 const fs = require('fs');
 

--- a/src/apps/communities/database.js
+++ b/src/apps/communities/database.js
@@ -1,6 +1,9 @@
 const sqlite3 = require('sqlite3').verbose();
 const fs = require('fs');
 
+const newStorageLimit = 4;  // How many posts maximum to store in the 'new' category.
+                            // Posts older than this limit will be deleted in clearOldPosts() as long as they are >7 days old.
+
 const dbLocation = 'db/communities.db';
 
 if(!fs.existsSync(dbLocation)) {
@@ -13,14 +16,28 @@ if(!fs.existsSync(dbLocation)) {
 
 const db = new sqlite3.Database(dbLocation);
 
+// Removes old posts >7 days old from new in community DB, keeping newStorageLimit posts at the end.
+function clearOldPosts(community, currentBlock) {
+   const query = 'DELETE FROM ' + community + ' WHERE (SELECT max(rowid) FROM '+ community + ') - ' + newStorageLimit + ' > rowid AND block < ' + (currentBlock - 20160);
+
+   db.run(query, [], function(err) {
+     if(err) {
+       throw err;
+     }
+   });
+}
+
 module.exports = {
   post: function(community, block, author, permlink) {
-    const query = 'INSERT INTO ' + community + '(block, author, permlink) VALUES (?,?,?)';
+    // Insert value and at the same time remove all val
+    const query = 'INSERT INTO ' + community + '(block, author, permlink) VALUES (?,?,?);';
     db.run(query, [block, author, permlink], function(err){
       if(err) {
         throw err
       }
     });
+
+    clearOldPosts(community, block);
   },
 
   create: function(community) {
@@ -32,7 +49,7 @@ module.exports = {
   },
 
   getNew: function(community, limit, callback) {
-    const query = 'SELECT * FROM ' + community + ' ORDER BY block DESC LIMIT ' + limit;
+    const query = 'SELECT DISTINCT rowid, author, permlink, block FROM ' + community + ' ORDER BY block DESC LIMIT ' + limit;
 
     db.all(query, [], function(err, rows) {
       if(err) {

--- a/src/apps/communities/database.js
+++ b/src/apps/communities/database.js
@@ -1,7 +1,7 @@
 const sqlite3 = require('sqlite3').verbose();
 const fs = require('fs');
 
-const newStorageLimit = 4;  // How many posts maximum to store in the 'new' category.
+const newStorageLimit = 1000;  // How many posts maximum to store in the 'new' category.
                             // Posts older than this limit will be deleted in clearOldPosts() as long as they are >7 days old.
 
 const dbLocation = 'db/communities.db';

--- a/src/apps/communities/database.js
+++ b/src/apps/communities/database.js
@@ -127,5 +127,37 @@ module.exports = {
 
       callback(rows[0].metadata);
     });
+  },
+
+  getCommunityOfPost: function(author, permlink, callback) {
+    const query = 'SELECT DISTINCT * FROM new_posts WHERE author = ? AND permlink = ?'
+
+    db.all(query, [author, permlink], function(err, rows1) {
+      if(err) {
+        throw err
+      }
+
+      if(rows1.length > 0) {
+        const community = rows1[0].community
+        // If it has a community see if it is featured
+        const query2 = 'SELECT DISTINCT * FROM featured_posts WHERE author = ? AND permlink = ? AND community = ?'
+
+        db.all(query2, [author, permlink, community], function(err, rows2) {
+          if(rows2.length > 0) {
+            callback({
+              featured: true,
+              community: community
+            });
+          } else {
+            callback({
+              featured: false,
+              community: community
+            });
+          }
+        });
+      } else {
+        callback({});
+      }
+    })
   }
 }

--- a/src/apps/communities/database.js
+++ b/src/apps/communities/database.js
@@ -4,19 +4,42 @@ const fs = require('fs');
 const dbLocation = 'db/communities.db';
 
 if(!fs.existsSync(dbLocation)) {
-  fs.mkdirSync('db/')
+  if(!fs.existsSync('db/')) {
+    fs.mkdirSync('db/')
+  }
   const createStream = fs.createWriteStream('db/communities.db');
   createStream.end();
 }
 
 const db = new sqlite3.Database(dbLocation);
 
-return {
-  post: function() {
-
+module.exports = {
+  post: function(community, block, author, permlink) {
+    const query = 'INSERT INTO ' + community + '(block, author, permlink) VALUES (?,?,?)';
+    db.run(query, [block, author, permlink], function(err){
+      if(err) {
+        throw err
+      }
+    });
   },
 
-  create: function() {
+  create: function(community) {
+    db.run('CREATE TABLE IF NOT EXISTS ' + community + '(block, author, permlink)', function(err){
+      if(err) {
+        throw err
+      }
+    });
+  },
 
+  getNew: function(community, limit, callback) {
+    const query = 'SELECT * FROM ' + community + ' ORDER BY block DESC LIMIT ' + limit;
+
+    db.all(query, [], function(err, rows) {
+      if(err) {
+        throw err
+      }
+
+      callback(rows);
+    });
   }
 }

--- a/src/apps/communities/database.js
+++ b/src/apps/communities/database.js
@@ -37,6 +37,12 @@ db.run('CREATE TABLE IF NOT EXISTS featured_posts(community, block, author, feat
   }
 });
 
+db.run('CREATE TABLE IF NOT EXISTS community_meta(community, metadata)', function(err) {
+  if(err) {
+    throw err
+  }
+});
+
 module.exports = {
   post: function(community, block, author, permlink) {
     // Insert value and at the same time remove all val
@@ -93,5 +99,33 @@ module.exports = {
     db.run(query2, [author, permlink, community], function(err) {
       if(err) {throw err}
     })
+  },
+
+  create: function(community) {
+    const query = 'INSERT INTO community_meta(community, metadata) VALUES (?,?)'
+
+    db.run(query, [community, '{}'], function(err) {
+      if(err) {throw err}
+    })
+  },
+
+  updateMeta: function(community, metadata) {
+    const query = 'UPDATE community_meta SET metadata=? WHERE community=?'
+
+    db.run(query, [metadata, community], function(err) {
+      if(err) {throw err}
+    })
+  },
+
+  getMeta: function(community, callback) {
+    const query = 'SELECT DISTINCT * FROM community_meta WHERE community = ? LIMIT 1'
+
+    db.all(query, [community], function(err, rows) {
+      if(err) {
+        throw err
+      }
+
+      callback(rows[0].metadata);
+    });
   }
 }

--- a/src/apps/communities/index.js
+++ b/src/apps/communities/index.js
@@ -1,6 +1,8 @@
 const matcher = require('match-schema');
 const schemas = require('./schemas');
 
+const database = require('./database');
+
 function canEditRole(state, user, community, role) { // Roles 'owner', 'admin', 'moderator', 'author'
   try {
     const roles = state.communities[community].roles
@@ -114,7 +116,6 @@ function app(processor, getState, setState, prefix) {
       if(community) {
         if(state.communities[community] && canPost(state, json.author, community)) {
           console.log('post')
-          // Actual post behaviour here
         }
       }
     }
@@ -124,7 +125,7 @@ function app(processor, getState, setState, prefix) {
   return processor;
 }
 
-function cli(input, getState) {
+function cli(input, getState, prefix) {
   input.on('communities_create', function(args, transactor, username, key) {
     const id = args[0];
 
@@ -176,11 +177,11 @@ function cli(input, getState) {
         {
             author: username,
             body: 'Test post',
-            json_metadata: args.slice(1).join(' '),
+            json_metadata: '{"' + prefix + 'cmmts_post":"' + args[1] + '"}',
             parent_author: '',
             parent_permlink: 'test',
             permlink: 'testing-testing-1-2-3' + args[0],
-            title: 'Test title',
+            title: 'Test post'
         },
         dsteem.PrivateKey.fromString(key)
     )

--- a/src/apps/communities/index.js
+++ b/src/apps/communities/index.js
@@ -1,12 +1,107 @@
 const matcher = require('match-schema');
 const schemas = require('./schemas');
 
+function hasRole(state, user, community, role) { // Roles 'owner', 'admin', 'moderator', 'author'
+  try {
+    const roles = state.communities[community].roles
+
+    if(roles.owner.indexOf(user) !== -1 || roles.owner.indexOf('eo') !== -1) {  // @eo means everyone.
+      return true;
+    } else if(roles.admin.indexOf(user) !== -1 || roles.admin.indexOf('eo') !== -1) {
+      if(role === 'owner') {
+        return false;
+      } else {
+        return true;
+      }
+    } else if(roles.mod.indexOf(user) !== -1 || roles.mod.indexOf('eo') !== -1) {
+      if(role === 'mod' || role === 'author') {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  } catch(err) {
+    return false;
+  }
+}
+
 function app(processor, getState, setState, prefix) {
+  processor.on('communities_create', function(json, from) {
+    var state = getState()
+    const {matched, errorKey} = matcher.match(json, schemas.createCommunity);
+    if(matched && state.communities[json.id] === undefined) {
+      state.communities[json.id] = {
+        roles: {
+          owner: [
+            from
+          ],
+          admin: [],
+          mod: [],
+          author: []
+        },
+        posts: {
+
+        }
+      }
+
+      console.log(from, 'created community', json.id);
+    } else {
+      console.log('Invalid community creation from', from)
+    }
+    setState(state)
+  });
+
+  processor.on('communities_grant_role', function(json, from) {
+    var state = getState();
+    const {matched, errorKey} = matcher.match(json, schemas.grantRole);
+    if(matched && state.communities[json.community] !== undefined && (json.role === 'owner' || json.role === 'mod' || json.role === 'admin' || json.role === 'author')) {
+      // Check authorization
+      if(hasRole(state, from, json.community, json.role)) {
+        console.log(from, 'granted role', json.role, 'to', json.receiver);
+        state.communities[json.community].roles[json.role].push(json.receiver)
+      } else {
+        console.log(from, 'tried to grant role but lacked proper permissions.')
+      }
+    } else {
+      console.log('Invalid role grant from', from)
+    }
+
+    setState(state);
+  });
+
   return processor;
 }
 
 function cli(input, getState) {
+  input.on('communities_create', function(args, transactor, username, key) {
+    const id = args[0];
 
+    transactor.json(username, key, 'communities_create', {
+      id: id
+    }, function(err, result) {
+      if(err) {
+        console.error(err);
+      }
+    });
+  });
+
+  input.on('communities_grant_role', function(args, transactor, username, key) {
+    const role = args[0];
+    const receiver = args[1];
+    const community = args[2];
+
+    transactor.json(username, key, 'communities_grant_role', {
+      community: community,
+      receiver: receiver,
+      role: role
+    }, function(err, result) {
+      if(err) {
+        console.error(err);
+      }
+    });
+  });
 }
 
 function api(app, getState) {

--- a/src/apps/communities/index.js
+++ b/src/apps/communities/index.js
@@ -1,3 +1,10 @@
+/*
+  Communities
+  ---
+
+  Implementation of Steem communities, which are similar to subreddits on Reddit.
+*/
+
 const matcher = require('match-schema');
 const schemas = require('./schemas');
 

--- a/src/apps/communities/index.js
+++ b/src/apps/communities/index.js
@@ -1,0 +1,20 @@
+const matcher = require('match-schema');
+const schemas = require('./schemas');
+
+function app(processor, getState, setState, prefix) {
+  return processor;
+}
+
+function cli(input, getState) {
+
+}
+
+function api(app, getState) {
+  return app;
+}
+
+module.exports = {
+  app: app,
+  cli: cli,
+  api: api
+}

--- a/src/apps/communities/index.js
+++ b/src/apps/communities/index.js
@@ -322,13 +322,11 @@ function api(app, getState) {
     });
   });
 
-  /*app.get('/communities/:community/roles', (req, res, next) => {
-    try {
-      res.send(JSON.stringify(getState().communities[req.params.community].roles, null, 2));
-    } catch (err) {
-      res.send({})
-    }
-  });*/
+  app.get('/communities/@:author/:permlink/community', (req, res, next) => {
+    database.getCommunityOfPost(req.params.author, req.params.permlink, function(response) {
+      res.send(JSON.stringify(response, null, 2));
+    });
+  });
 
   return app;
 }

--- a/src/apps/communities/index.js
+++ b/src/apps/communities/index.js
@@ -212,6 +212,14 @@ function api(app, getState) {
     });
   })
 
+  app.get('/communities/:community/roles', (req, res, next) => {
+    try {
+      res.send(JSON.stringify(getState().communities[req.params.community].roles, null, 2));
+    } catch (err) {
+      res.send({})
+    }
+  });
+
   return app;
 }
 

--- a/src/apps/communities/index.js
+++ b/src/apps/communities/index.js
@@ -65,8 +65,6 @@ function app(processor, getState, setState, prefix) {
         }
       }
 
-      database.create(json.id);
-
       console.log(from, 'created community', json.id);
     } else {
       console.log('Invalid community creation from', from)

--- a/src/apps/communities/index.js
+++ b/src/apps/communities/index.js
@@ -47,8 +47,6 @@ function canPost(state, user, community) {
 }
 
 function app(processor, getState, setState, prefix) {
-  database.setup(processor.getCurrentBlockNumber());
-
   processor.on('cmmts_create', function(json, from) {
     var state = getState()
     const {matched, errorKey} = matcher.match(json, schemas.createCommunity);
@@ -341,5 +339,6 @@ function api(app, getState) {
 module.exports = {
   app: app,
   cli: cli,
-  api: api
+  api: api,
+  database: database
 }

--- a/src/apps/communities/schemas.js
+++ b/src/apps/communities/schemas.js
@@ -1,0 +1,26 @@
+const createCommunity = {
+  type: 'object',
+  id: {
+    type: 'string',
+    alphabet: 'abcdefghijklmnopqrstuvwxyz-'
+  }
+}
+
+const grantRole = {
+  type: 'object',
+  community: {
+    type: 'string',
+    alphabet: 'abcdefghijklmnopqrstuvwxyz-'
+  },
+  receiver: {
+    type: 'string'
+  },
+  role: {
+    type: 'string'
+  }
+}
+
+module.exports = {
+  createCommunity: createCommunity,
+  grantRole: grantRole
+}

--- a/src/apps/communities/schemas.js
+++ b/src/apps/communities/schemas.js
@@ -36,8 +36,40 @@ const removeRole = {
   }
 }
 
+const blockPost = {
+  type: 'object',
+
+  permlink: {
+    type: 'string'
+  },
+  author: {
+    type: 'string'
+  },
+  community: {
+    type: 'string',
+    alphabet: communityIdAlphabet
+  }
+}
+
+const featurePost = {
+  type: 'object',
+
+  permlink: {
+    type: 'string'
+  },
+  author: {
+    type: 'string'
+  },
+  community: {
+    type: 'string',
+    alphabet: communityIdAlphabet
+  }
+}
+
 module.exports = {
   createCommunity: createCommunity,
   grantRole: grantRole,
-  removeRole: removeRole
+  removeRole: removeRole,
+  blockPost: blockPost,
+  featurePost: featurePost
 }

--- a/src/apps/communities/schemas.js
+++ b/src/apps/communities/schemas.js
@@ -66,10 +66,19 @@ const featurePost = {
   }
 }
 
+const updateMeta = {
+  type: 'object',
+
+  metadata: {
+    type: 'string'
+  }
+}
+
 module.exports = {
   createCommunity: createCommunity,
   grantRole: grantRole,
   removeRole: removeRole,
   blockPost: blockPost,
-  featurePost: featurePost
+  featurePost: featurePost,
+  updateMeta: updateMeta
 }

--- a/src/apps/communities/schemas.js
+++ b/src/apps/communities/schemas.js
@@ -1,8 +1,10 @@
+const communityIdAlphabet = 'abcdefghijklmnopqrstuvwxyz-';
+
 const createCommunity = {
   type: 'object',
   id: {
     type: 'string',
-    alphabet: 'abcdefghijklmnopqrstuvwxyz-'
+    alphabet: communityIdAlphabet
   }
 }
 
@@ -10,7 +12,21 @@ const grantRole = {
   type: 'object',
   community: {
     type: 'string',
-    alphabet: 'abcdefghijklmnopqrstuvwxyz-'
+    alphabet: communityIdAlphabet
+  },
+  receiver: {
+    type: 'string'
+  },
+  role: {
+    type: 'string'
+  }
+}
+
+const removeRole = {
+  type: 'object',
+  community: {
+    type: 'string',
+    alphabet: communityIdAlphabet
   },
   receiver: {
     type: 'string'
@@ -22,5 +38,6 @@ const grantRole = {
 
 module.exports = {
   createCommunity: createCommunity,
-  grantRole: grantRole
+  grantRole: grantRole,
+  removeRole: removeRole
 }

--- a/src/apps/communities/schemas.js
+++ b/src/apps/communities/schemas.js
@@ -1,4 +1,4 @@
-const communityIdAlphabet = 'abcdefghijklmnopqrstuvwxyz-';
+const communityIdAlphabet = 'abcdefghijklmnopqrstuvwxyz';
 
 const createCommunity = {
   type: 'object',

--- a/src/apps/communities/schemas.js
+++ b/src/apps/communities/schemas.js
@@ -1,4 +1,4 @@
-const communityIdAlphabet = 'abcdefghijklmnopqrstuvwxyz';
+const communityIdAlphabet = 'abcdefghijklmnopqrstuvwxyz-';
 
 const createCommunity = {
   type: 'object',

--- a/src/apps/dex/index.js
+++ b/src/apps/dex/index.js
@@ -1,3 +1,14 @@
+/*
+  dex
+  ---
+
+  Decentralized exchange between SRTS and STEEM. This exchange is not symmetrical;
+  there is no such thing as buy orders. One can create a sell order, then others
+  can fill the sell order by sending STEEM with a specific memo. Allowing limit buy
+  orders introduces added complexity as soft-consensus apps cannot interact directly
+  with the STEEM currency.
+*/
+
 const matcher = require('match-schema');
 const schemas = require('./schemas');
 

--- a/src/apps/grant-voting/index.js
+++ b/src/apps/grant-voting/index.js
@@ -1,3 +1,11 @@
+/*
+  Grant voting
+  ---
+
+  Allows voting for granters. See src/distribute_grants.js
+
+*/
+
 const matcher = require('match-schema');
 const schemas = require('./schemas');
 

--- a/src/apps/token/index.js
+++ b/src/apps/token/index.js
@@ -1,3 +1,11 @@
+/*
+  token
+  ---
+
+  The SRTS token. This can be transferred to others and is minted by grant
+  distribution (see src/distribute_grants.js).
+*/
+
 const matcher = require('match-schema');
 const schemas = require('./schemas');
 

--- a/src/distribute_grants.js
+++ b/src/distribute_grants.js
@@ -1,3 +1,12 @@
+/*
+  Grant Distribution
+  ---
+
+  Implementation of Stratos grant distribution, as seen in Steem post
+  https://steemit.com/steem/@shredz7/a-model-for-a-decentralized-open-company-stratos-update
+
+  
+*/
 
 const maxGranters = 3;
 

--- a/src/distribute_grants.js
+++ b/src/distribute_grants.js
@@ -45,20 +45,20 @@ function distributeGrants(state, block) {
   const topGranters = sortedGranters.slice(0, maxGranters);
 
   // Distribute rewards
-  const rewardPerGranter = Math.floor(state.rewardPool/topGranters.length);
+  if(topGranters.length !== 0) {
+    const rewardPerGranter = Math.floor(state.rewardPool/topGranters.length);
 
-  for(granterNum in topGranters) {
-    const granter = topGranters[granterNum].granter;
-    console.log("Top granter",granter,"received",rewardPerGranter);
+    for(granterNum in topGranters) {
+      const granter = topGranters[granterNum].granter;
+      console.log("Top granter",granter,"received",rewardPerGranter);
 
-    if(state.balances[granter] === undefined) {
-      state.balances[granter] = 0;
+      if(state.balances[granter] === undefined) {
+        state.balances[granter] = 0;
+      }
+
+      state.balances[granter] += rewardPerGranter;
     }
-
-    state.balances[granter] += rewardPerGranter;
   }
-
-
 
   state.rewardPool = getRewardPool(block);
   return state;

--- a/src/distribute_grants.js
+++ b/src/distribute_grants.js
@@ -66,7 +66,7 @@ function distributeGrants(state, block) {
 
 // Placeholder reward pool function. Actual function TBD.
 function getRewardPool(block) {
-  return dailyRewardDistribution = 100000;
+  return 0;
 }
 
 

--- a/src/genesis.js
+++ b/src/genesis.js
@@ -1,3 +1,5 @@
+// Contains the constants which determine the original state and the block the network starts at.
+
 const genesisState = {
   balances: {
     shredz7: 9900000,

--- a/src/genesis.js
+++ b/src/genesis.js
@@ -7,7 +7,8 @@ const genesisState = {
   dex: {},
   granters: {},
   rewardPool: 100000,
-  granterVotes: {}
+  granterVotes: {},
+  communities: {}
 };
 
 const genesisBlock = 28934806;

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,7 @@ function startApp(startingBlock) {
     if(typeof inputToFunction[split[0]] === 'function') {
       const funcToCall = inputToFunction[split[0]];
       split.shift(); // Remove split[0]
-      funcToCall(split, transactor, username, key);
+      funcToCall(split, transactor, username, key, client, steem);
     } else {
       console.log("Invalid command.");
     }

--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,7 @@ function startApp(startingBlock) {
   token.cli(inputInterface, getState);
   dex.cli(inputInterface, getState);
   grantVoting.cli(inputInterface, getState);
-  communities.cli(inputInterface, getState);
+  communities.cli(inputInterface, getState, fullPrefix);
 
 
   rl.on('line', function(data) {
@@ -174,7 +174,7 @@ function startApp(startingBlock) {
   app = token.api(app, getState);
   app = dex.api(app, getState);
   app = grantVoting.api(app, getState);
-  app = communities.api(app, getState);
+  app = communities.api(app, getState, fullPrefix);
 
   app.listen(port, function() {
     console.log(`stratos API listening on port ${port}!`)
@@ -211,7 +211,7 @@ if(fs.existsSync(stateStoreFile)) { // If we have saved the state in a previous 
   state = json[2]; // The state will be set to the one linked to the starting block.
   lastCheckpointHash = json[1];
   consensusDisagreements = json[3];
-  startApp(startingBlock);
+  startApp(startingBlock)
 } else {   // If this is the first run
   console.log('No state store file found. Starting from the genesis block + state (this is not a warning, everything is OK, this is to be expected)');
   const startingBlock = genesisBlock;  // Simply start at the genesis block.

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ function startApp(startingBlock) {
   processor = dex.app(processor,getState,setState, fullPrefix);
   processor = grantVoting.app(processor, getState, setState, fullPrefix);
   processor = communities.app(processor, getState, setState, fullPrefix);
-
+  communities.database.setup(startingBlock);
   setTimeout(processor.start, 1000);
   console.log('Started state processor.');
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const genesis = require('./genesis');
 const dex = require('./apps/dex');
 const token = require('./apps/token');
 const grantVoting = require('./apps/grant-voting');
+const communities = require('./apps/communities');
 
 const distributeGrants = require('./distribute_grants');
 
@@ -78,8 +79,7 @@ function startApp(startingBlock) {
 
     if(num % checkpointDelay === 0) {
       lastCheckpointHash = hash(state);
-      //if(processor.isStreaming && postCheckpoints) {
-      if(postConsensusCheck) {
+      if(processor.isStreaming() && postConsensusCheck) {
         console.log('Posting consensus check')
 
         transactor.json(username, key, 'consensus_check', lastCheckpointHash, function(err, result) {
@@ -114,6 +114,7 @@ function startApp(startingBlock) {
   processor = token.app(processor,getState,setState, fullPrefix);
   processor = dex.app(processor,getState,setState, fullPrefix);
   processor = grantVoting.app(processor, getState, setState, fullPrefix);
+  processor = communities.app(processor, getState, setState, fullPrefix);
 
   processor.start();
   console.log('Started state processor.');
@@ -133,6 +134,7 @@ function startApp(startingBlock) {
   token.cli(inputInterface, getState);
   dex.cli(inputInterface, getState);
   grantVoting.cli(inputInterface, getState);
+  communities.cli(inputInterface, getState);
 
 
   rl.on('line', function(data) {
@@ -159,6 +161,7 @@ function startApp(startingBlock) {
   app = token.api(app, getState);
   app = dex.api(app, getState);
   app = grantVoting.api(app, getState);
+  app = communities.api(app, getState);
 
   app.listen(port, function() {
     console.log(`stratos API listening on port ${port}!`)

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,11 @@
+/*
+  Index.js
+  ---
+
+  Sets up state storage in memory and in files, runs distribute_grants, sets
+  up APIs, CLI, and operation events by utilizing files in src/apps/
+*/
+
 const steem = require('dsteem');
 const steemState = require('steem-state');
 const steemTransact = require('steem-transact');

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ const postConsensusCheck = process.env.CONSENSUS_CHECKS === 'true'
 
 const streamMode = process.env.STREAM_MODE || 'irreversible'  // Stream irreversible or latest?
 console.log('Using mode', streamMode)
-const rpcEndpoint = process.env.RPC_ENDPOINT || 'https://api.steemit.com'   // Use which client?
+const rpcEndpoint = process.env.RPC_ENDPOINT || 'https://rpc.usesteem.com'   // Use which client?
 console.log('Using endpoint', rpcEndpoint)
 const saveStateHistory = ('true' === process.env.SAVE_STATE_HISTORY)  // Whether to store a record of the history of the state; if true saves state every 100 blocks into states/ directory
                                                                       // Converts save_state_history to true/false

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,7 @@ function startApp(startingBlock) {
   processor = grantVoting.app(processor, getState, setState, fullPrefix);
   processor = communities.app(processor, getState, setState, fullPrefix);
 
-  processor.start();
+  setTimeout(processor.start, 1000);
   console.log('Started state processor.');
 
   var inputToFunction = {}    // An input action cooresponds to a function

--- a/test/communities-test.js
+++ b/test/communities-test.js
@@ -26,7 +26,7 @@ describe('communities', function() {
       communities: {}
     }
 
-    processor.triggerCustomJson('communities_create', 'alice', {
+    processor.triggerCustomJson('cmmts_create', 'alice', {
       id: 'test-community'
     })
 
@@ -38,7 +38,7 @@ describe('communities', function() {
       communities: {}
     }
 
-    processor.triggerCustomJson('communities_create', 'alice', {
+    processor.triggerCustomJson('cmmts_create', 'alice', {
       id: 'invalID iD #$@QE@#!_'
     })
 
@@ -59,7 +59,7 @@ describe('communities', function() {
       }
     }
 
-    processor.triggerCustomJson('communities_grant_role', 'alice', {
+    processor.triggerCustomJson('cmmts_grant_role', 'alice', {
       community: 'test',
       receiver: 'bob',
       role: 'admin'
@@ -67,7 +67,7 @@ describe('communities', function() {
 
     expect(state.communities.test.roles.admin[0]).to.eql('bob');
 
-    processor.triggerCustomJson('communities_grant_role', 'bob', {
+    processor.triggerCustomJson('cmmts_grant_role', 'bob', {
       community: 'test',
       receiver: 'carl',
       role: 'mod'
@@ -75,7 +75,7 @@ describe('communities', function() {
 
     expect(state.communities.test.roles.mod[0]).to.eql('carl');
 
-    processor.triggerCustomJson('communities_grant_role', 'carl', {
+    processor.triggerCustomJson('cmmts_grant_role', 'carl', {
       community: 'test',
       receiver: 'dan',
       role: 'author'
@@ -89,18 +89,44 @@ describe('communities', function() {
       communities: {
         test: {
           roles: {
-            mod: ['alice']
+            mod: ['alice'],
+            admin: [],
+            owner: [],
+            author: []
           }
         }
       }
     };
 
-    processor.triggerCustomJson('communities_grant_role', 'alice', {
+    processor.triggerCustomJson('cmmts_grant_role', 'alice', {
       community: 'test',
       receiver: 'bob',
       role: 'admin'
     });
 
-    expect(state.communities.test.roles.admin).to.equal(undefined);
-  })
+    expect(state.communities.test.roles.admin.length).to.equal(0);
+  });
+
+  it('Removes roles', function() {
+    state = {
+      communities: {
+        test: {
+          roles: {
+            admin: [],
+            owner: [],
+            mod: ['alice'],
+            author: ['bob']
+          }
+        }
+      }
+    };
+
+    processor.triggerCustomJson('cmmts_remove_role', 'alice', {
+      community: 'test',
+      receiver: 'bob',
+      role: 'author'
+    });
+
+    expect(state.communities.test.roles.author.length).to.equal(0);
+  });
 });

--- a/test/communities-test.js
+++ b/test/communities-test.js
@@ -1,0 +1,106 @@
+const expect = require('chai').expect
+
+const dummySteemState = require('./steem-state-clone')
+const communities = require('../src/apps/communities')
+
+
+describe('communities', function() {
+  var processor;
+  var state;
+
+  function getState() {
+    return state;
+  }
+  function setState(value) {
+    state = value;
+  }
+
+
+  beforeEach(function () {
+    processor = dummySteemState();    // Initialize a dummy steem state to use to trigger transactions artificially
+    communities.app(processor, getState, setState,'test_prefix_');    // Initialize communities
+  });
+
+  it('Creates a community successfully', function() {
+    state = {
+      communities: {}
+    }
+
+    processor.triggerCustomJson('communities_create', 'alice', {
+      id: 'test-community'
+    })
+
+    expect(state.communities['test-community'].roles.owner[0]).to.eql('alice');
+  })
+
+  it('Does not create a community with invalid id', function() {
+    state = {
+      communities: {}
+    }
+
+    processor.triggerCustomJson('communities_create', 'alice', {
+      id: 'invalID iD #$@QE@#!_'
+    })
+
+    expect(state.communities['test-community']).to.equal(undefined);
+  })
+
+  it('Successfully grants roles to users', function() {
+    state = {
+      communities: {
+        test: {
+          roles: {
+            owner: ['alice'],
+            admin: [],
+            mod: [],
+            author: []
+          }
+        }
+      }
+    }
+
+    processor.triggerCustomJson('communities_grant_role', 'alice', {
+      community: 'test',
+      receiver: 'bob',
+      role: 'admin'
+    });
+
+    expect(state.communities.test.roles.admin[0]).to.eql('bob');
+
+    processor.triggerCustomJson('communities_grant_role', 'bob', {
+      community: 'test',
+      receiver: 'carl',
+      role: 'mod'
+    });
+
+    expect(state.communities.test.roles.mod[0]).to.eql('carl');
+
+    processor.triggerCustomJson('communities_grant_role', 'carl', {
+      community: 'test',
+      receiver: 'dan',
+      role: 'author'
+    });
+
+    expect(state.communities.test.roles.author[0]).to.eql('dan');
+  })
+
+  it('Does not grant roles to unauthorized users', function() {
+    state = {
+      communities: {
+        test: {
+          roles: {
+            mod: ['alice']
+          }
+        }
+      }
+    };
+
+    processor.triggerCustomJson('communities_grant_role', 'alice', {
+      community: 'test',
+      receiver: 'bob',
+      role: 'admin'
+    });
+
+    expect(state.communities.test.roles.admin).to.equal(undefined);
+  })
+});


### PR DESCRIPTION
This implements communities similarly to as described in the Steem 2017 Roadmap https://steem.com/2017roadmap.pdf.

Anyone can create a community with `cmmts_create` with id [id]. A community's ID should never be displayed to the end user and is restricted to only the lowercase alphabet including dashes (-). They will automatically receive the role 'owner'. Then they can assign roles owner, admin, mod, author to other users by using `cmmts_grant_role` with role receiver [receiver], role [role], and in community id [community]. They can also remove the role by using `cmmts_remove_role` with the same permissions. If a role is granted to the nonexistent account @eo, then it is considered granted to everyone by the node software. This allows for public communities where anyone can post.

Here are the permissions each role has. Note that each role can remove any other user in the same role or below (except author which can only post).

![image](https://user-images.githubusercontent.com/34197135/51503310-f80b3380-1d9f-11e9-98e7-95e9d9fd1dc6.png)

Anyone with role author or above can post by creating a post with a property json_metadata of the full network prefix (for mainnet this would be `stratos_0_`) plus `cmmts_post` (for example in mainnet this would be `stratos_0_cmmts_post`) containing the id of the community to post to.

Anyone with role mod or above can block (remove) a post by creating a `cmmts_block_post` operation with permlink [permlink], author [author], and in community id [community].

Anyone with role mod or above can feature a post by creating a `cmmts_feature` operation with permlink [permlink], author [author], and in community id [community].

That's the basis of transactions, documentation for APIs will follow soon.


